### PR TITLE
Headless Keyboard detection

### DIFF
--- a/harbour-wlan-keyboard-html/app/js/app.js
+++ b/harbour-wlan-keyboard-html/app/js/app.js
@@ -8,7 +8,7 @@ var wsEndpoint = '__WS_ENDPOINT__';
 var debugCheck = '__WS_' + 'ENDPOINT__';
 
 if (wsEndpoint == debugCheck) {
-    wsEndpoint = 'ws://192.168.1.165:8890';
+    wsEndpoint = 'ws://192.168.1.165:8893';
 }
 
 console.log("Booting sailfish-wlan-keyboard frontend");

--- a/harbour-wlan-keyboard-html/app/js/components/WlanKeyboard.react.js
+++ b/harbour-wlan-keyboard-html/app/js/components/WlanKeyboard.react.js
@@ -50,33 +50,32 @@ var WlanKeyboard = React.createClass({
             <div>
                 <div className="container">
                     <Header/>
-                    <section className="configuration">
-                        <div className="configuration__status">
-                            <div className={(this.state.moreOptions ? "configuration__button--selected " : " " ) + " configuration__button text__center"}
-                                onClick={this._onMoreOptionsClicked}>
-                                 ...
-                            </div>
-                        </div>
-
-                        <div className="configuration__status">
-                            <ConnectionStatus status={this.state.status} className="text__center"/>
-                        </div>
-                    </section>
-
-
-                    <section className={(this.state.moreOptions ? "": "invisible ") + "clipboard "}>
-                        <div>
-
-                            <div className="clibparod__input_icon ">
-                            <img className="clipboard__img" src="img/clipboard.png" />
+                        <section className="configuration">
+                            <div className={(this.state.keyMode != AppConstants.KeyMode.HEADLESS ? "invisible" : "") + " configuration__status"} >
+                                <div className={(this.state.moreOptions ? "configuration__button--selected " : " " ) + " configuration__button text__center"}
+                                    onClick={this._onMoreOptionsClicked}>
+                                     ...
+                                </div>
                             </div>
 
-                            <div className="clipboard__textarea__outer">
-                                <textarea className="clipboard__textarea" readOnly="true" placeholder="Empty phone clipboard" value={this.state.clipboard} />
+                            <div className="configuration__status">
+                                <ConnectionStatus status={this.state.status} className="text__center"/>
                             </div>
+                        </section>
 
-                        </div>
-                    </section>
+                        <section className={(this.state.moreOptions ? "": "invisible ") + "clipboard "}>
+                            <div>
+
+                                <div className="clibparod__input_icon ">
+                                <img className="clipboard__img" src="img/clipboard.png" />
+                                </div>
+
+                                <div className="clipboard__textarea__outer">
+                                    <textarea className="clipboard__textarea" readOnly="true" placeholder="Empty phone clipboard" value={this.state.clipboard} />
+                                </div>
+
+                            </div>
+                        </section>
 
                     <section className="footer">
                         <div className="lineHead">

--- a/harbour-wlan-keyboard-html/app/js/stores/WlanKeyboardStore.js
+++ b/harbour-wlan-keyboard-html/app/js/stores/WlanKeyboardStore.js
@@ -10,7 +10,7 @@ var _serverSettings = {};
 
 var _connectionStatus = {};
 
-var _keyMode = _keyMode || WlanKeyboardConstants.KeyMode.HEADLESS;
+var _keyMode = _keyMode || WlanKeyboardConstants.KeyMode.CLIPBOARD;
 
 var _phoneClipboard = "";
 

--- a/harbour-wlan-keyboard/qml/components/AppEvents.qml
+++ b/harbour-wlan-keyboard/qml/components/AppEvents.qml
@@ -12,14 +12,13 @@ Item {
     property bool connectivityAvailable: true
     property bool serverRunning
 
-    property bool inForeground: true
-
     property int serverState:
         (notifications.serverRunning && notifications.connectivityAvailable) ? _SERVER_STATE_ACTIVE :
            (!notifications.serverRunning && notifications.connectivityAvailable) ? _SERVER_STATE_INACTIVE :
                 _SERVER_STATE_NO_CONNECTIVITY
 
      signal onStateReload()
+     signal applicationStateActive(bool active) // active if in foreground
 
     Connections {
         target: httpServer
@@ -33,6 +32,7 @@ Item {
         onApplicationStateChanged: {
             console.log("application state: " + state);
             connectivityTimer.running = (state == 4); // 4 =  active
+            applicationStateActive(state == 4);
         }
     }
 

--- a/harbour-wlan-keyboard/qml/pages/PageHeadlessMode.qml
+++ b/harbour-wlan-keyboard/qml/pages/PageHeadlessMode.qml
@@ -47,9 +47,20 @@ Page {
             }
 
             SectionHeader {
+                text: qsTr("Phone clipboard")
+                font.bold: true
+            }
+
+            Label {
+                text: qsTr("This mode features a bidirectional text exchange so you can access your phone clipboard on your computer.")
+                width: parent.width
+                wrapMode: Text.Wrap
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+
+            SectionHeader {
                 text: qsTr("Configuration")
                 font.bold: true
-                //height: Theme.paddingMedium
             }
 
             /*

--- a/harbour-wlan-keyboard/qml/pages/PageHeadlessMode.qml
+++ b/harbour-wlan-keyboard/qml/pages/PageHeadlessMode.qml
@@ -63,45 +63,10 @@ Page {
                 font.bold: true
             }
 
-            /*
-            ComboBox {
-                id: submodeComboBox
-                width: page.width
-                label: "Headless mode"
-                anchors.left: parent.left
-                anchors.leftMargin: 0
-                menu: ContextMenu {
-                    MenuItem { text: "Continuous" }
-                    MenuItem { text: "Return key based" }
-                }
-            }
-
-            Label {
-                text: "Option <b>Continuous</b> delegates incoming keystrokes to the focused widget. The text appears instantly."
-                width: parent.width
-                wrapMode: Text.Wrap
-                font.pixelSize: Theme.fontSizeTiny
-            }
-
-            Label {
-                text: "Option <b>Return key based</b> caches incoming keystrokes until return is hit before the text appears."
-                width: parent.width
-                wrapMode: Text.Wrap
-                font.pixelSize: Theme.fontSizeTiny
-            }
-
-
-            SectionHeader {
-                text: "Installation"
-                font.bold: true
-                //height: Theme.paddingMedium
-            } */
-
             Label {
                 text: qsTr("To use this mode, you need to install the <b> headless keyboard </b> extension.")
                 width: parent.width
                 wrapMode: Text.Wrap
-                //horizontalAlignment: Text.AlignHCenter
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 
@@ -109,21 +74,18 @@ Page {
                 text: qsTr("The headless keyboard extension is completely Free and Open Source Software. Due to harbor policies, it needs to be distributed in an alternative store. Therefore, you install it on your own risk.")
                 width: parent.width
                 wrapMode: Text.Wrap
-                //horizontalAlignment: Text.AlignHCenter
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 
             SectionHeader {
                 text: qsTr("Download")
                 font.bold: true
-                //height: Theme.paddingMedium
             }
 
             Label {
                 text: qsTr("Download the keyboard with the Button below or take a look at the <a href='https://github.com/abertschi/sailfish-headless-keyboard-layout'>source code</a>.")
                 width: parent.width
                 wrapMode: Text.Wrap
-                //horizontalAlignment: Text.AlignHCenter
                 anchors.horizontalCenter: parent.horizontalCenter
 
                 MouseArea {
@@ -140,7 +102,6 @@ Page {
                     remorse.execute(qsTr("Browsing Download Page "), function() { Qt.openUrlExternally("https://openrepos.net/content/abertschi/headless-keyboard"); } )
                 }
             }
-
         }
     }
 }

--- a/harbour-wlan-keyboard/qml/pages/TabConfig.qml
+++ b/harbour-wlan-keyboard/qml/pages/TabConfig.qml
@@ -152,13 +152,28 @@ Item {
                 }
             }
             */
+
+
             ComboBox {
                 id: keyboardMode
+                Component.onCompleted: resetLabels()
+
+                Connections {
+                    target: headlessKeyboard
+                    onRunningChanged: {
+                        if (isRunning) {
+                            keyboardMode.resetLabels();
+                        }
+                        else {
+                            keyboardMode.showHeadlessError();
+                        }
+                    }
+                }
+
                 width: parent.width
                 label: qsTr("Keyboard mode")
                 currentIndex: settings.keyboardMode === settings._KEYBOARD_MODE_CLIPBOARD ? 0 : 1
                 anchors.left: parent.left
-                description: qsTr("Mode to process incoming keystrokes")
                 menu: ContextMenu {
                     MenuItem { text: qsTr("Clipboard") }
                     MenuItem { text: qsTr("Headless") }
@@ -177,6 +192,20 @@ Item {
                         settings.keyboardMode = settings._KEYBOARD_MODE_HEADLESS
                         app.openPageHeadlessMode()
                     }
+                }
+
+                function showHeadlessError() {
+                    keyboardMode.labelColor = "red"
+                    keyboardMode.valueColor= "red"
+                    keyboardMode.description =
+                            qsTr("Mode to process incoming keystrokes") + "<br />" +"<b>" + qsTr("Headless Keyboard not detected") + "</b>"
+                }
+
+                function resetLabels() {
+                    keyboardMode.labelColor = "white"
+                    keyboardMode.valueColor= Theme.highlightColor
+                    keyboardMode.description =
+                            qsTr("Mode to process incoming keystrokes")
                 }
             }
         }

--- a/harbour-wlan-keyboard/qml/pages/TabConfig.qml
+++ b/harbour-wlan-keyboard/qml/pages/TabConfig.qml
@@ -156,7 +156,7 @@ Item {
 
             ComboBox {
                 id: keyboardMode
-                Component.onCompleted: resetLabels()
+                Component.onCompleted: headlessKeyboard.isRunning() ? keyboardMode.resetLabels() : keyboardMode.showHeadlessError();
 
                 Connections {
                     target: headlessKeyboard

--- a/harbour-wlan-keyboard/qml/pages/TabConfig.qml
+++ b/harbour-wlan-keyboard/qml/pages/TabConfig.qml
@@ -156,7 +156,7 @@ Item {
 
             ComboBox {
                 id: keyboardMode
-                Component.onCompleted: headlessKeyboard.isRunning() ? keyboardMode.resetLabels() : keyboardMode.showHeadlessError();
+                Component.onCompleted:  checkHeadlessAvailability()
 
                 Connections {
                     target: headlessKeyboard
@@ -192,13 +192,23 @@ Item {
                         settings.keyboardMode = settings._KEYBOARD_MODE_HEADLESS
                         app.openPageHeadlessMode()
                     }
+                     checkHeadlessAvailability()
+                }
+
+                function checkHeadlessAvailability() {
+                    if (!headlessKeyboard.isRunning() && settings.keyboardMode == settings._KEYBOARD_MODE_HEADLESS) {
+                        console.log("Showing Headless Error");
+                        keyboardMode.showHeadlessError();
+                    } else {
+                        console.log("Resetting Headless Error");
+                        keyboardMode.resetLabels()
+                    }
                 }
 
                 function showHeadlessError() {
                     keyboardMode.labelColor = "red"
                     keyboardMode.valueColor= "red"
-                    keyboardMode.description =
-                            qsTr("Mode to process incoming keystrokes") + "<br />" +"<b>" + qsTr("Headless Keyboard not detected") + "</b>"
+                    keyboardMode.description = "<b>" + qsTr("Headless Keyboard not detected") + "</b>"
                 }
 
                 function resetLabels() {

--- a/harbour-wlan-keyboard/rpm/harbour-wlan-keyboard.changes.in
+++ b/harbour-wlan-keyboard/rpm/harbour-wlan-keyboard.changes.in
@@ -29,5 +29,10 @@
 - change cover page
 - add server animations
 - headless keyboard mode can be used with any installed keyboard layout
-        -
+
+* Tue Sep 22 2015 Andrin Bertschi <andrin.bertschi@gmail.com> 0.4.1
+- add headless keyboard detection
+- disable feature to access phone clipboard if headless keyboard not installed
+                -
+
 

--- a/harbour-wlan-keyboard/rpm/harbour-wlan-keyboard.spec
+++ b/harbour-wlan-keyboard/rpm/harbour-wlan-keyboard.spec
@@ -16,7 +16,7 @@ Name:       harbour-wlan-keyboard
 %{!?qtc_make:%define qtc_make make}
 %{?qtc_builddir:%define _builddir %qtc_builddir}
 Summary:    The sailfish-wlan-keyboard provides an easy way to use you your computer keyboard to type on your phone.
-Version:    0.4.0
+Version:    0.4.1
 Release:    1
 Group:      Qt/Qt
 License:    GNU GENERAL PUBLIC LICENSE Version 3

--- a/harbour-wlan-keyboard/rpm/harbour-wlan-keyboard.yaml
+++ b/harbour-wlan-keyboard/rpm/harbour-wlan-keyboard.yaml
@@ -1,6 +1,6 @@
 Name: harbour-wlan-keyboard
 Summary: The sailfish-wlan-keyboard provides an easy way to use you your computer keyboard to type on your phone.
-Version: 0.4.0
+Version: 0.4.1
 Release: 1
 # The contents of the Group field should be one of the groups listed here:
 # http://gitorious.org/meego-developer-tools/spectacle/blobs/master/data/GROUPS

--- a/harbour-wlan-keyboard/src/harbour-wlan-keyboard.cpp
+++ b/harbour-wlan-keyboard/src/harbour-wlan-keyboard.cpp
@@ -49,7 +49,6 @@ static QJSValue appVersionSingletonProvider(QQmlEngine *engine, QJSEngine *scrip
     return appInfo;
 }
 
-
 int main(int argc, char *argv[])
 {
     QScopedPointer<QGuiApplication> app(SailfishApp::application(argc, argv));
@@ -67,11 +66,9 @@ int main(int argc, char *argv[])
 
     Settings &settings = Settings::getInstance();
     view->rootContext()->setContextProperty("_qtSettings", &settings);
-    //qmlRegisterType<Settings>("harbour.wlan.keyboard",1,0,"Settings");
 
     view->setSource(SailfishApp::pathTo("qml/harbour-wlan-keyboard.qml") );
     view->showFullScreen();
 
     return app->exec();
-
 }

--- a/harbour-wlan-keyboard/src/headless_keyboard_delegate.cpp
+++ b/harbour-wlan-keyboard/src/headless_keyboard_delegate.cpp
@@ -4,11 +4,11 @@ HeadlessKeyboardDelegate::HeadlessKeyboardDelegate(QObject *parent) : QObject(pa
 {
     this->m_service_watcher = new QDBusServiceWatcher(SERVICE, QDBusConnection::sessionBus());
 
-    QObject::connect(m_service_watcher, SIGNAL(serviceRegistered(const QString&)),
-                     this, SLOT(serviceRegistered(const QString&)));
+    QObject::connect(m_service_watcher, SIGNAL(serviceRegistered(QString)),
+                     this, SLOT(onServiceRegistered(QString)));
 
-    QObject::connect(m_service_watcher, SIGNAL(serviceUnregistered(const QString&)),
-                     this, SLOT(serviceUnregistered(const QString&)));
+    QObject::connect(m_service_watcher, SIGNAL(serviceUnregistered(QString)),
+                     this, SLOT(onServiceUnRegistered(QString)));
 
     this->m_dbus_iface = new QDBusInterface(SERVICE, PATH, IF_NAME, QDBusConnection::sessionBus(), parent);
     if (! m_dbus_iface->isValid())

--- a/harbour-wlan-keyboard/src/headless_keyboard_delegate.cpp
+++ b/harbour-wlan-keyboard/src/headless_keyboard_delegate.cpp
@@ -2,18 +2,28 @@
 
 HeadlessKeyboardDelegate::HeadlessKeyboardDelegate(QObject *parent) : QObject(parent)
 {
+    this->m_service_watcher = new QDBusServiceWatcher(SERVICE, QDBusConnection::sessionBus());
+
+    QObject::connect(m_service_watcher, SIGNAL(serviceRegistered(const QString&)),
+                     this, SLOT(serviceRegistered(const QString&)));
+
+    QObject::connect(m_service_watcher, SIGNAL(serviceUnregistered(const QString&)),
+                     this, SLOT(serviceUnregistered(const QString&)));
+
     this->m_dbus_iface = new QDBusInterface(SERVICE, PATH, IF_NAME, QDBusConnection::sessionBus(), parent);
     if (! m_dbus_iface->isValid())
     {
-        qDebug() << "dbus interface is invalid";
-        //exit(1); // todo
+        qDebug() << "dbus interface " << SERVICE << " is invalid";
+        m_is_running = false;
+        runningChanged(false);
     }
     qDebug() << "dbus connection successfully created";
     QDBusConnection::sessionBus().connect(SERVICE,
                                           PATH,
                                           IF_NAME,
                                           "receive_clipboard_changed",
-                                          this, SLOT(receive_clibpoard_changed_private(QString)));
+                                          this, SLOT(onClipboardChangedPrivate(QString)));
+
 }
 
 HeadlessKeyboardDelegate:: ~ HeadlessKeyboardDelegate()
@@ -67,7 +77,8 @@ void HeadlessKeyboardDelegate::send_key_arrow (ArrowDirection direction)
 
 void HeadlessKeyboardDelegate::send_keyboard_label(QString label)
 {
-    m_dbus_iface->asyncCall("send_keyboard_label", label);
+    //m_dbus_iface->asyncCall("send_keyboard_label", label);
+    qDebug() << "Feature is not supported";
 }
 
 void HeadlessKeyboardDelegate::send_enable_debug(bool enabled)
@@ -80,7 +91,27 @@ void HeadlessKeyboardDelegate::send_enable_keyboard()
     m_dbus_iface->asyncCall("send_enable_keyboard");
 }
 
-void HeadlessKeyboardDelegate::receive_clibpoard_changed_private(QString cb)
+void HeadlessKeyboardDelegate::onClipboardChangedPrivate(QString cb)
 {
-    emit on_clipboard_set(cb);
+    emit onClipboardChanged(cb);
+}
+
+bool HeadlessKeyboardDelegate::isRunning()
+{
+    return m_is_running;
+}
+
+void HeadlessKeyboardDelegate::onServiceRegistered(QString s)
+{
+    qDebug() << "headless mode service was registered " << s;
+    m_is_running = true;
+    emit runningChanged(true);
+
+}
+
+void HeadlessKeyboardDelegate::onServiceUnRegistered(QString s)
+{
+    qDebug() << "headless mode service was unregistered " << s;
+    m_is_running = false;
+    emit runningChanged(false);
 }

--- a/harbour-wlan-keyboard/src/headless_keyboard_delegate.cpp
+++ b/harbour-wlan-keyboard/src/headless_keyboard_delegate.cpp
@@ -77,7 +77,6 @@ void HeadlessKeyboardDelegate::send_key_arrow (ArrowDirection direction)
 
 void HeadlessKeyboardDelegate::send_keyboard_label(QString label)
 {
-    //m_dbus_iface->asyncCall("send_keyboard_label", label);
     qDebug() << "Feature is not supported";
 }
 

--- a/harbour-wlan-keyboard/src/headless_keyboard_delegate.h
+++ b/harbour-wlan-keyboard/src/headless_keyboard_delegate.h
@@ -31,16 +31,22 @@ public:
     void send_keyboard_label(QString label);
     void send_enable_debug(bool enabled);
     void send_enable_keyboard();
+    bool isRunning();
 
 private slots:
-    void receive_clibpoard_changed_private(QString cb);
+    void onClipboardChangedPrivate(QString cb);
+    void onServiceRegistered(QString s);
+    void onServiceUnRegistered(QString s);
 
 Q_SIGNALS:
 signals:
-        void on_clipboard_set(QString cb);
+        void onClipboardChanged(QString cb);
+        void runningChanged(bool isRunning);
 
 private:
     QDBusInterface * m_dbus_iface;
+    QDBusServiceWatcher * m_service_watcher;
+    bool m_is_running;
 
 };
 #endif // HEADLESS_KEYBOARD_DELEGATE_H

--- a/harbour-wlan-keyboard/src/headless_keyboard_delegate.h
+++ b/harbour-wlan-keyboard/src/headless_keyboard_delegate.h
@@ -42,8 +42,8 @@ private slots:
 
 Q_SIGNALS:
 signals:
-        void onClipboardChanged(QString cb);
-        void runningChanged(bool isRunning);
+    void onClipboardChanged(QString cb);
+    void runningChanged(bool isRunning);
 
 private:
     QDBusInterface * m_dbus_iface;

--- a/harbour-wlan-keyboard/src/headless_keyboard_delegate.h
+++ b/harbour-wlan-keyboard/src/headless_keyboard_delegate.h
@@ -11,6 +11,7 @@
 class HeadlessKeyboardDelegate : public QObject
 {
     Q_OBJECT
+
 public:
     explicit HeadlessKeyboardDelegate(QObject *parent = 0);
     virtual ~ HeadlessKeyboardDelegate();
@@ -31,7 +32,8 @@ public:
     void send_keyboard_label(QString label);
     void send_enable_debug(bool enabled);
     void send_enable_keyboard();
-    bool isRunning();
+
+    Q_INVOKABLE bool isRunning();
 
 private slots:
     void onClipboardChangedPrivate(QString cb);

--- a/harbour-wlan-keyboard/src/http_server.h
+++ b/harbour-wlan-keyboard/src/http_server.h
@@ -16,9 +16,9 @@ public:
     explicit http_server(QObject *parent = 0);
     virtual ~ http_server();
 
+    void startServer(const QHostAddress &address, qint16 port);
     Q_INVOKABLE void startServerBroadcast(qint16 port);
     Q_INVOKABLE void startServer(const QString interfaceName, qint16 port);
-    void startServer(const QHostAddress &address, qint16 port);
     Q_INVOKABLE void stopServer();
 
     Q_INVOKABLE bool isRunning() const;
@@ -26,11 +26,9 @@ public:
     Q_INVOKABLE void setBasePath(QString filePath);
     Q_INVOKABLE void setError404File(QString filePath);
 
-
     Q_INVOKABLE QString getStaticContent();
 
     Q_INVOKABLE qint16 getPort() const;
-
     Q_INVOKABLE QStringList getFullAddresses() const;
     Q_INVOKABLE QStringList getIpAddresses() const;
 

--- a/harbour-wlan-keyboard/src/server_configurator.cpp
+++ b/harbour-wlan-keyboard/src/server_configurator.cpp
@@ -28,14 +28,15 @@ void ServerConfigurator::configure(QQuickView *view)
     Settings * s = &Settings::getInstance();
     connect(s, SIGNAL(settingsChanged(Settings*)), this, SLOT(onSettingsChanged(Settings*)));
 
-    connect(m_headless_keyboard, SIGNAL(on_clipboard_set(QString)), this, SLOT(onPhoneClipboardChanged(QString)));
-    //connect()
+    view->rootContext()->setContextProperty("headlessKeyboard", m_headless_keyboard);
+    connect(m_headless_keyboard, SIGNAL(onClipboardChanged(QString)), this, SLOT(onPhoneClipboardChanged(QString)));
 }
 
 void ServerConfigurator::modifyHtmlContent(QString *content)
 {
     QString addr = m_websocket_server->getFullAddresses().at(0);
-    if(content->contains(ENDPOINT_MARKER)) {
+    if(content->contains(ENDPOINT_MARKER))
+    {
         *content = content->replace(ENDPOINT_MARKER, addr) ;
     }
 }

--- a/harbour-wlan-keyboard/src/server_configurator.cpp
+++ b/harbour-wlan-keyboard/src/server_configurator.cpp
@@ -97,8 +97,6 @@ void ServerConfigurator::processInsertText(QString text)
     }
     else
     {
-        QString label = m_http_server->getFullAddresses().at(0);
-        m_headless_keyboard->send_keyboard_label(label);
         m_headless_keyboard->send_text(text);
         qDebug() << "Sending keystroke to headless end: " << text;
     }

--- a/harbour-wlan-keyboard/src/server_configurator.cpp
+++ b/harbour-wlan-keyboard/src/server_configurator.cpp
@@ -54,7 +54,7 @@ void ServerConfigurator::onPhoneClipboardChanged(QString cb)
     // In this case, notifications about clipboard changes are not
     // useful. TODO
 
-    qDebug() << "CB: recognized cb change with text: " << cb;
+    qDebug() << "Clipboard change was detected" << cb;
     sendClipboardToClients(cb);
 }
 
@@ -96,7 +96,7 @@ void ServerConfigurator::processInsertText(QString text)
         m_keyboardUtils->setClipboard(text);
     }
     else
-    { // Settings::KeyboardMode::HEADLESS
+    {
         QString label = m_http_server->getFullAddresses().at(0);
         m_headless_keyboard->send_keyboard_label(label);
         m_headless_keyboard->send_text(text);

--- a/harbour-wlan-keyboard/src/utils.h
+++ b/harbour-wlan-keyboard/src/utils.h
@@ -16,7 +16,6 @@ public:
     Q_INVOKABLE static int getAvailableEndpointSize();
 
     static QHostAddress getHostAddressByInterfaceName(QString name);
-    //static QList<QHostAddress> Utils::getAllHostAdresses();
 
     void setClipboard(QString content);
     QClipboard * getClipboard();
@@ -34,6 +33,5 @@ private:
     QClipboard *m_clipboard;
 
 };
-
 
 #endif // UTILS_H

--- a/harbour-wlan-keyboard/src/websocket_server.h
+++ b/harbour-wlan-keyboard/src/websocket_server.h
@@ -15,7 +15,6 @@ class websocket_server : public QObject
     Q_OBJECT
 
     Q_PROPERTY(bool m_isRunning READ isRunning NOTIFY runningChanged)
-
     Q_PROPERTY(int m_numberOfClients READ getNumberOfClients NOTIFY numberOfClientsChanged)
 
 public:
@@ -23,8 +22,9 @@ public:
 
     virtual ~ websocket_server();
 
-    Q_INVOKABLE void startServerBroadcast(qint16 port = 7777);
     void startServer(const QHostAddress &address, qint16 m_port);
+
+    Q_INVOKABLE void startServerBroadcast(qint16 port = 7777);
     Q_INVOKABLE void startServer(const QString address, qint16 port);
     Q_INVOKABLE void stopServer();
 

--- a/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-de.ts
+++ b/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-de.ts
@@ -147,6 +147,14 @@
         <source>The headless keyboard extension is completely Free and Open Source Software. Due to harbor policies, it needs to be distributed in an alternative store. Therefore, you install it on your own risk.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Phone clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This mode features a bidirectional text exchange so you can access your phone clipboard on your computer.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RuntimeActiveState</name>

--- a/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-de.ts
+++ b/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-de.ts
@@ -227,6 +227,10 @@
         <source>Headless</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Headless Keyboard not detected</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>harbour-wlan-keyboard</name>

--- a/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-sv.ts
+++ b/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-sv.ts
@@ -227,6 +227,10 @@
         <source>Headless</source>
         <translation>Headless</translation>
     </message>
+    <message>
+        <source>Headless Keyboard not detected</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>harbour-wlan-keyboard</name>

--- a/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-sv.ts
+++ b/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-sv.ts
@@ -147,6 +147,14 @@
         <source>The headless keyboard extension is completely Free and Open Source Software. Due to harbor policies, it needs to be distributed in an alternative store. Therefore, you install it on your own risk.</source>
         <translation>Headless keyboard-tillägget är fri och öppen källkodsmjukvara. På grund av Jolla Store policy, måste den distribueras från alternativt förråd. Därför installerar du på egen risk.</translation>
     </message>
+    <message>
+        <source>Phone clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This mode features a bidirectional text exchange so you can access your phone clipboard on your computer.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RuntimeActiveState</name>

--- a/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-zh_CN.ts
+++ b/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-zh_CN.ts
@@ -227,6 +227,10 @@
         <source>Headless</source>
         <translation>极简</translation>
     </message>
+    <message>
+        <source>Headless Keyboard not detected</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>harbour-wlan-keyboard</name>

--- a/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-zh_CN.ts
+++ b/harbour-wlan-keyboard/translations/harbour-wlan-keyboard-zh_CN.ts
@@ -147,6 +147,14 @@
         <source>The headless keyboard extension is completely Free and Open Source Software. Due to harbor policies, it needs to be distributed in an alternative store. Therefore, you install it on your own risk.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Phone clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This mode features a bidirectional text exchange so you can access your phone clipboard on your computer.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RuntimeActiveState</name>

--- a/harbour-wlan-keyboard/translations/harbour-wlan-keyboard.ts
+++ b/harbour-wlan-keyboard/translations/harbour-wlan-keyboard.ts
@@ -147,6 +147,14 @@
         <source>The headless keyboard extension is completely Free and Open Source Software. Due to harbor policies, it needs to be distributed in an alternative store. Therefore, you install it on your own risk.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Phone clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This mode features a bidirectional text exchange so you can access your phone clipboard on your computer.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RuntimeActiveState</name>

--- a/harbour-wlan-keyboard/translations/harbour-wlan-keyboard.ts
+++ b/harbour-wlan-keyboard/translations/harbour-wlan-keyboard.ts
@@ -227,6 +227,10 @@
         <source>Headless</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Headless Keyboard not detected</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>harbour-wlan-keyboard</name>


### PR DESCRIPTION
Add mechanism to detect if the headless keyboard extension is installed.
- Display message if not detected
- Currently, the phone clipboard can only be detected if the headless keyboard is installed. Therefore the corresponding feature in the web frontend should not be available if the app is not running in headless mode.
